### PR TITLE
Git-LocalGroupMembership

### DIFF
--- a/Get-LocalGroupMembership.ps1
+++ b/Get-LocalGroupMembership.ps1
@@ -147,15 +147,23 @@
                     [System.DirectoryServices.DirectoryEntry]$LocalGroup
                 )
                 # Invoke the Members method and convert to an array of member objects.
-                $Members= @($LocalGroup.psbase.Invoke("Members"))
-                $Counter++
+                #Change3 comment from web page by Craig Dempsey to fixe Powershell 5.0 issue
+				#$Members= @($LocalGroup.psbase.Invoke("Members"))
+                $Members= @($LocalGroup.psbase.Invoke("Members")) | foreach{([System.DirectoryServices.DirectoryEntry]$_)}
+				$Counter++
                 ForEach ($Member In $Members) {                
                     Try {
-                        $Name = $Member.GetType().InvokeMember("Name", 'GetProperty', $Null, $Member, $Null)
-                        $Path = $Member.GetType().InvokeMember("ADsPath", 'GetProperty', $Null, $Member, $Null)
-                        # Check if this member is a group.
-                        $isGroup = ($Member.GetType().InvokeMember("Class", 'GetProperty', $Null, $Member, $Null) -eq "group")
-                        
+						#Change3
+                        #$Name = $Member.GetType().InvokeMember("Name", 'GetProperty', $Null, $Member, $Null)
+                        #$Path = $Member.GetType().InvokeMember("ADsPath", 'GetProperty', $Null, $Member, $Null)
+                        $Name = $Member.InvokeGet("Name")
+						$Path = $Member.InvokeGet("AdsPath")
+
+						# Check if this member is a group.
+                        #Change3
+						#$isGroup = ($Member.GetType().InvokeMember("Class", 'GetProperty', $Null, $Member, $Null) -eq "group")
+                        $isGroup = ($Member.InvokeGet("Class") -eq "group")
+
 						#region Change1 by Kensel
 						#Remove the domain from the computername to fix the type comparison when supplied with FQDN
 						IF ($Computer.Contains('.')){


### PR DESCRIPTION
Modified Git-LocalGroupMembership
1. Added change to strip the .domain.dom from a FQDN computer that caused the path check to fail and cause all output to be type domain.  
1. Modified output to include the group allowing for the output to be saved to the same object and be able to export easier to csv for report.
   $Result = Get-LocalGroupMembership -Group Administrators
   $Result += Get-LocalGroupMembership -Group 'Remote Desktop Users'
   $Result | ConvertTo-CSV -NoTypeInformation | Out-File .\LocalGroups.csv
2. Added Craig Dempsey's changes from the blog to fix bug in Powershell 5 causing errors.
