### PR TITLE
Update to MessageType parameter

### DIFF
--- a/Invoke-BalloonTip.ps1
+++ b/Invoke-BalloonTip.ps1
@@ -43,7 +43,7 @@
          [string]$Title="Attention $env:username",
 
         [Parameter(HelpMessage="The message type: Info,Error,Warning,None")]
-        [System.Windows.Forms.ToolTipIcon]$MessageType="Info",
+        [string]$MessageType="Info",
      
         [Parameter(HelpMessage="The path to a file to use its icon in the system tray")]
         [string]$SysTrayIconPath='C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe',     


### PR DESCRIPTION
Can't call [System.Windows.Forms.ToolTipIcon] before assembly, it's called later on line 78 instead.